### PR TITLE
[Rubin] Add options to confluent for schema registry installation

### DIFF
--- a/containerfs/rubin/deps/requirements.txt
+++ b/containerfs/rubin/deps/requirements.txt
@@ -11,14 +11,13 @@ healpy
 astropy
 astroquery
 
-# > 1.9. see https://github.com/edenhill/librdkafka/issues/3263
-confluent-kafka==2.12.1
+confluent-kafka[avro,schemaregistry]==2.12.1
 avro-python3
 fastavro==1.9.4
 
 # Fink core
-fink_filters>=7.9
-fink-utils>=0.48.0
+fink_filters>=7.11
+fink-utils>=0.50.0
 fink-spins>=0.3.8
 fink-tns>=0.14
 

--- a/containerfs/ztf/deps/requirements.txt
+++ b/containerfs/ztf/deps/requirements.txt
@@ -18,8 +18,8 @@ avro-python3
 fastavro==1.6.0
 
 # Fink core
-fink_filters>=7.9
-fink-utils>=0.48.0
+fink_filters>=7.11
+fink-utils>=0.50.0
 fink-spins>=0.3.8
 fink-tns>=0.14
 


### PR DESCRIPTION
In the last image, `stream2raw` was failing with:

```python
🛈 Reading custom Fink stream2raw configuration file from  /__w/fink-broker/fink-broker/conf/rubin/fink.conf.stream2raw
Traceback (most recent call last):
  File "/__w/fink-broker/fink-broker/bin/rubin/stream2raw.py", line 35, in <module>
    from confluent_kafka.schema_registry import SchemaRegistryClient
  File "/opt/fink-broker/miniconda/lib/python3.11/site-packages/confluent_kafka/schema_registry/__init__.py", line 21, in <module>
    from .schema_registry_client import (
  File "/opt/fink-broker/miniconda/lib/python3.11/site-packages/confluent_kafka/schema_registry/schema_registry_client.py", line 20, in <module>
    from ._async.schema_registry_client import *  # noqa
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/fink-broker/miniconda/lib/python3.11/site-packages/confluent_kafka/schema_registry/_async/schema_registry_client.py", line 28, in <module>
    import httpx
ModuleNotFoundError: No module named 'httpx'
```

Weirdly, we never had this problem with `Sentinel/Rubin` before, but indeed installing `confluent_kafka` is not enough, one also needs options for the registry. This PR solves it. I also bump fink-filters and fink-utils to latest.