### PR TITLE
Update fink_sn_activelearning dependency version

### DIFF
--- a/containerfs/rubin/deps/requirements-science.txt
+++ b/containerfs/rubin/deps/requirements-science.txt
@@ -7,7 +7,7 @@ git+https://github.com/astrolabsoftware/fink-science@8.30.0
 line_profiler==4.1.3
 
 # Active learning
-git+https://github.com/emilleishida/fink_sn_activelearning.git@cb61bbb34630c7811862050389b0f993de9639c7#egg=actsnfink
+git+https://github.com/emilleishida/fink_sn_activelearning.git@c920ca1bf82ceedd4a401d4cf6d7b2b4cf7b1734#egg=actsnfink  
 git+https://github.com/COINtoolbox/ActSNClass.git@2c61da91a9d13834d39804fc35aeb3245ba20755#egg=actsnclass
 joblib==1.2.0
 


### PR DESCRIPTION
Updated the GitHub link for the fink_sn_activelearning dependency to a new commit hash.