### PR TITLE
Build images with fink-science fix/remove-pandas-udf-type and fix CI tag detection

### DIFF
--- a/.github/workflows/build-image-template.yml
+++ b/.github/workflows/build-image-template.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Maximize build space
         run: |

--- a/.github/workflows/build-image-template.yml
+++ b/.github/workflows/build-image-template.yml
@@ -48,6 +48,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Fetch tags
+        run: git fetch --tags --force
+
       - name: Maximize build space
         run: |
           echo "Removing unwanted software... "

--- a/.github/workflows/build-image-template.yml
+++ b/.github/workflows/build-image-template.yml
@@ -106,9 +106,9 @@ jobs:
           echo "## 🐳 Built Image" >> $GITHUB_STEP_SUMMARY
           echo "**Image URL:** \`${{ steps.build.outputs.image-url }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "```bash" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
           echo "docker pull ${{ steps.build.outputs.image-url }}" >> $GITHUB_STEP_SUMMARY
-          echo "```" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
           # Push with latest tag if on main branch
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
@@ -126,9 +126,9 @@ jobs:
           echo "## ♻️ Existing Image" >> $GITHUB_STEP_SUMMARY
           echo "**Image URL:** \`${{ steps.build.outputs.image-url }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "```bash" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
           echo "docker pull ${{ steps.build.outputs.image-url }}" >> $GITHUB_STEP_SUMMARY
-          echo "```" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
           echo "*No new build was needed - image already exists*" >> $GITHUB_STEP_SUMMARY
 
       - name: Apply version tag to existing image

--- a/containerfs/rubin/deps/requirements-science.txt
+++ b/containerfs/rubin/deps/requirements-science.txt
@@ -1,7 +1,7 @@
 # Fink-science dependencies
 # WARNING: fink-science pip module is deprecated and fink-science is now installed from source
 
-git+https://github.com/astrolabsoftware/fink-science@8.50.0
+git+https://github.com/astrolabsoftware/fink-science@8.51.0
 
 # xmatch_cds
 line_profiler==4.1.3

--- a/containerfs/ztf/deps/requirements-science.txt
+++ b/containerfs/ztf/deps/requirements-science.txt
@@ -1,7 +1,7 @@
 # Fink-science dependencies
 # WARNING: fink-science pip module is deprecated and fink-science is now installed from source
 
-git+https://github.com/astrolabsoftware/fink-science@8.50.0
+git+https://github.com/astrolabsoftware/fink-science@8.51.0
 
 # xmatch_cds
 line_profiler==4.1.3

--- a/containerfs/ztf/deps/requirements-science.txt
+++ b/containerfs/ztf/deps/requirements-science.txt
@@ -1,5 +1,4 @@
 # Fink-science dependencies
-# WARNING: fink-science pip module is deprecated and fink-science is now installed from source
 
 git+https://github.com/astrolabsoftware/fink-science@8.51.0
 


### PR DESCRIPTION
## Summary


⚠️ **Warning:** astrolabsoftware/fink-broker-images#37 temporarily points its fink-science dependency at this branch (`fix/remove-pandas-udf-type`). That reference must be updated to a tagged release once this PR is merged.

- Point fink-science dependency (ZTF and Rubin requirements) to the `fix/remove-pandas-udf-type` branch, temporarily, until that PR is merged and a new fink-science release is tagged
- Fetch tags explicitly in CI (`fetch-tags: true` + `git fetch --tags --force`) so `ciux` correctly detects version tags
- Fix backticks/code-block quoting in the GitHub Actions step summary

## Related
- astrolabsoftware/fink-science#705
- astrolabsoftware/fink-broker#1200